### PR TITLE
Add clawr.ing — phone calling for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1439,6 +1439,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [Chatbot](https://github.com/YidaHu/chatbot) - 基于LLM的聊天机器人，AI Agent的自主智能体，利用Function、Tools、Agent来实现LLM自主工作
 - [Claude-Powered-Study-Assistant](https://github.com/g-hano/Claude-Powered-Study-Assistant) - A study assistant powered by Claude Opus. It provides various tools to assist with different tasks, such as researching,coding,note-takin…
 - [Claudesync](https://github.com/jahwag/ClaudeSync) - ClaudeSync is a Python tool that automates the synchronization of local files with Claude.ai Projects
+- [Clawr.ing](https://clawr.ing) - Phone calling skill for AI agents (OpenClaw). Lets agents make real outbound phone calls to users for alerts, briefings, reminders, and urgent notifications. Managed service, 100+ countries, 70+ voices. [website](https://clawr.ing)
 - [Code-Interpreter-Api](https://github.com/leezhuuuuu/Code-Interpreter-Api) - Committed to being the best code interpreter in the world.
 - [Comfyui-Llm-Tools](https://github.com/pridkett/ComfyUI-llm-tools) - Helpful nodes for working with LLMs inside of ComfyUI
 - [Companion](https://github.com/rapmd73/Companion) - An AI-powered Discord bot blending playful conversation with smart moderation tools, adding charm and order to your server.


### PR DESCRIPTION
Adds [clawr.ing](https://clawr.ing) to the **Tools** section.

**clawr.ing** is a phone calling skill for AI agents (OpenClaw). It lets agents make real outbound phone calls to users for alerts, briefings, reminders, and urgent notifications. Managed service covering 100+ countries with 70+ voices.