### PR TITLE
Add AIP (Agent Identity Protocol) to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1210,6 +1210,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [Yival](https://github.com/YiVal/YiVal) - Your Automatic Prompt Engineering Assistant for GenAI Applications
 
 ### Security
+- [Aip-Identity](https://github.com/the-nexus-guard/aip) - Agent Identity Protocol (AIP) provides cryptographic identity (Ed25519/DID), vouch-based trust graphs, and end-to-end encrypted messaging for AI agents. CLI and Python SDK available on PyPI (`pip install aip-identity`) [github](https://github.com/the-nexus-guard/aip) | [website](https://the-nexus-guard.github.io/aip/) | [docs](https://aip-service.fly.dev/docs)
 - [Agent-Repoguardian](https://github.com/flexigpt/agent-repoguardian) - An AI agent that does security scans and vulnerability analysis of code
 - [Agentic_Security](https://github.com/msoedov/agentic_security) - Agentic LLM Vulnerability Scanner / AI red teaming kit
 - [Agentictrust](https://github.com/lab101-ai/agentictrust) - Observability, DevTool and Security Platfrom for AI Agents


### PR DESCRIPTION
Adding [AIP (Agent Identity Protocol)](https://github.com/the-nexus-guard/aip) to the Security section.

AIP provides cryptographic identity, vouch-based trust graphs, and end-to-end encrypted messaging for AI agents:
- Ed25519 keypairs with DID-based identity
- Agents vouch for each other to build trust
- Encrypted agent-to-agent messaging
- CLI + Python SDK on PyPI
- 309 tests, MIT licensed

Fits alongside existing security entries like Agentictrust and Agent-Repoguardian.