### PR TITLE
Add OpenClaw course - AI agents for non-technical entrepreneurs (£97)

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,8 @@ There are so many places to learn how to build AI agents! Here are some course a
 - [Multi-Agent system building with CrewAI](https://www.deeplearning.ai/short-courses/multi-ai-agent-systems-with-crewai)
 - [Serverless Agentic workflows with Amazon Bedrock](https://www.deeplearning.ai/short-courses/serverless-agentic-workflows-with-amazon-bedrock/)
 
+- [OpenClaw for CEOs: Run AI Agents That Actually Work](https://openclawapp.netlify.app/course/) - 10-module course teaching non-technical entrepreneurs to install, secure, and run OpenClaw AI agents 24/7. Covers security setup, token cost optimisation, cron scheduling, multi-agent orchestration, and phone control. Pay £2-15/month instead of £200+/month for SaaS. (£97)
+
 I also recommend this [YouTube Playlist](https://www.youtube.com/playlist?list=PLnH2pfPCPZsKhlUSP39nRzLkfvi_FhDdD), which has a range of tutorials.
 
 #### Cookbooks


### PR DESCRIPTION
Adding [OpenClaw for CEOs](https://openclawapp.netlify.app/course/) to the Online Courses section.

This course specifically targets non-technical entrepreneurs and business owners who want to run AI agents — filling a gap in this list which is mostly developer-focused courses.

**Key details:**
- 10 modules: security setup, token optimisation, cron scheduling, multi-agent orchestration, phone control
- Based on openclaw/openclaw (328k GitHub stars)
- Teaches real autonomous operation: agents running 24/7 without user input
- Cost model: £2-15/month API vs £200+/month SaaS alternatives
- Self-paced, no coding required