### PR TITLE
Add Knowledge Graph persistent memory tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1430,6 +1430,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 
 ### Tools
 - [Cortex](https://github.com/SKULLFIRE07/cortex-memory) - Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context across sessions. VSCode extension + CLI + MCP server. Free.
+- [Knowledge Graph](https://github.com/hilyfux/knowledge-graph) - Built on Anthropic internal engineering practices and Karpathy's AutoResearch methodology. A zero-dependency, git-native memory layer for Claude Code that persists learned context across sessions. Pure bash, ~3ms/event, privacy-first.
 - [3Gpp-Requirements-Tools](https://github.com/Adrian2901/3gpp-requirements-tools) - Tools for retrieving 3GPP standards and LLM-powered requirement elicitiation.
 - [Acm](https://github.com/dnanhkhoa/acm) - A dead-simple AI-powered CLI tool for effortlessly crafting meaningful Git commit messages
 - [Agent-Manager-Skill](https://github.com/fractalmind-ai/agent-manager-skill) - tmux + Python agent lifecycle manager for running multiple CLI AI agents (start/stop/monitor/assign) with cron-friendly scheduling.


### PR DESCRIPTION
## Summary\nAdd [Knowledge Graph](https://github.com/hilyfux/knowledge-graph) to the Tools section.\n\nWhy it fits:\n- Persistent memory layer for Claude Code and AI coding agents\n- Built on Anthropic internal engineering practices and Karpathy's AutoResearch methodology\n- Zero-dependency, git-native, privacy-first design\n- Solves session-to-session memory loss without extra infrastructure\n\nShort description used in the list:\n"Knowledge Graph — Built on Anthropic internal engineering practices & Karpathy's AutoResearch methodology. A zero-dependency, git-native memory layer for Claude Code that persists learned context across sessions. Pure bash, ~3ms/event, privacy-first."