### PR TITLE
Add Toprank to repository list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1612,6 +1612,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [Toolplanner](https://github.com/XiaoMi/toolplanner) - ToolPlanner - A Tool Augmented LLM for Multi Granularity Instructions with Path Planning and Feedback
 - [Toolqa](https://github.com/night-chen/ToolQA) - ToolQA, a new dataset to evaluate the capabilities of LLMs in answering challenging questions with external tools. It offers two levels …
 - [Tools](https://github.com/buildownai/tools) - Monorepository of LLM based t AI ools provided by BuildOwn.AI
+- [Toprank](https://github.com/nowork-studio/toprank) - Open-source Claude Code workflow for inspecting repositories, applying SEO and Google Ads fixes, and shipping repo-aware changes through autonomous coding-agent runs. [github](https://github.com/nowork-studio/toprank)
 - [Tora](https://github.com/microsoft/ToRA) - ToRA is a series of Tool-integrated Reasoning LLM Agents designed to solve challenging mathematical reasoning problems by interacting with …
 - [Trafilatura](https://github.com/adbar/trafilatura) - Python & Command-line tool to gather text and metadata on the Web - Crawling, scraping, extraction, output as CSV, JSON, HTML, MD, TXT, XML
 - [Unchained](https://github.com/aaronamelgar/unchained) - A Django-based tool for prompt engineering and LLM system evaluation.


### PR DESCRIPTION
## Summary
- add `Toprank` to the `Learning > Repositories` list
- describe it as an open-source Claude Code workflow that inspects repositories and applies repo-aware SEO and Google Ads changes

## Why it fits
- this repo welcomes AI-agent-related resources via PRs
- `Toprank` is an open-source autonomous coding workflow for Claude Code that reads a repository, applies code changes, and runs repo-aware SEO/SEM tasks
- `nowork-studio/toprank` currently has 124 GitHub stars
