### PR TITLE
Add Signet to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1285,6 +1285,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [Secad](https://github.com/gideonaina/secad) - SECAD is an agentic, AI-powered security workflow augmentation application.
 - [Security-Ai-Agent-Brama](https://github.com/oborys/security-ai-agent-brama) - No description available
 - [Sim-Security-Data](https://github.com/Sim-Security/Sim-Security-Data) - Where I collect and process data for AI agents
+- [Signet](https://github.com/Prismer-AI/signet) - Cryptographic action receipts for AI agents. Ed25519 signing, hash-chained audit trail, bilateral co-signing, policy engine, and MCP proxy. Rust core with Python and TypeScript SDKs. [github](https://github.com/Prismer-AI/signet) | [npm](https://www.npmjs.com/package/@signet-auth/core) | [pypi](https://pypi.org/project/signet-auth/)
 - [Vulert](https://vulert.com) - Vulert secures software by detecting vulnerabilities in open-source dependencies—without accessing your code. It supports Js, PHP, Java, Python, and more
 - [Web_Scrape_Agent_Ai](https://github.com/rxslice/Web_Scrape_Agent_AI) - Enterprise-Quality Autonomous Agent complete with relevant tools, master prompt, additional optional AI services, API compatible, basic s…
 


### PR DESCRIPTION
Add [Signet](https://github.com/Prismer-AI/signet) to the Security section.

Signet provides cryptographic action receipts for AI agents — Ed25519 signing, hash-chained audit trail, bilateral co-signing, policy engine, and MCP proxy. Rust core with Python and TypeScript SDKs.

- npm: [@signet-auth/core](https://www.npmjs.com/package/@signet-auth/core)
- PyPI: [signet-auth](https://pypi.org/project/signet-auth/)
- crates.io: [signet-core](https://crates.io/crates/signet-core)