### PR TITLE
Add OpenTwins under Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1576,6 +1576,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [Ollama-Mcp-Bridge](https://github.com/patruff/ollama-mcp-bridge) - Bridge between Ollama and MCP servers, enabling local LLMs to use Model Context Protocol tools
 - [Open-Webui-Tools](https://github.com/Haervwe/open-webui-tools) - a Repository of Open-WebUI tools to use with your favourite LLMs
 - [Openai-Tools](https://github.com/tipani86/OpenAI-Tools) - Toolkit to get the most out of your OpenAI Account
+- [OpenTwins](https://github.com/Open-Twin/opentwins) - Autonomous digital-twin agents for 10 social platforms (Reddit, Twitter/X, LinkedIn, Bluesky, Threads, Medium, Substack, Dev.to, Product Hunt, Indie Hackers). Runs a 7-stage content pipeline (trend scout → competitive intel → engagement tracker → network mapper → amplification → planner → writer), powered by Claude Code with a local dashboard. [github](https://github.com/Open-Twin/opentwins) | [website](https://opentwins.ai)
 - [Pathology_Llm](https://github.com/JaesikKim/pathology_llm) - GPT-4 as decision support tool in oncology
 - [Pentestgpt](https://github.com/GreyDGL/PentestGPT) - A GPT-empowered penetration testing tool
 - [Plasmate](https://github.com/plasmate-labs/plasmate) - A browser engine built for AI agents that compiles HTML into a Semantic Object Model (SOM), providing 10x token compression vs raw HTML. V8 JS rendering, CDP compatibility, authenticated browsing, MCP server [github](https://github.com/plasmate-labs/plasmate) | [docs](https://docs.plasmate.app)


### PR DESCRIPTION
## Adding OpenTwins

**Project:** [OpenTwins](https://github.com/Open-Twin/opentwins) — autonomous AI agents across 10 social platforms.

**Section:** Building › Tools (inserted alphabetically between `Openai-Tools` and `Pathology_Llm`)

**Why it belongs:**
- End-user CLI + dashboard built on Claude Code
- Autonomous agents running on 10 social platforms via real Chrome (CDP), not API scraping
- 7-stage content pipeline (trend scout → competitive intel → engagement tracker → network mapper → amplification → planner → writer)
- Open source, MIT, actively maintained (see [releases](https://github.com/Open-Twin/opentwins/releases))
- Has README, LICENSE, CONTRIBUTING, CODE_OF_CONDUCT, CHANGELOG, tests
- Published on npm: https://www.npmjs.com/package/opentwins

**Note on section choice:** `### Applications` (line 106) is a category taxonomy rather than an agent list, and `### Frameworks` is for agent frameworks (we use Claude Code, we're not one). `### Tools` is where real agent applications are listed alphabetically, so I inserted there. Happy to move if you prefer Marketing/Content-Creation.

**Checklist:**
- [x] Entry is alphabetically ordered within its section
- [x] Link returns 200
- [x] No duplicate entry
- [x] Description follows the list's style