### PR TITLE
Add Voidly Agent Relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1026,6 +1026,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [TeamHero](https://github.com/sagiyaacoby/TeamHero) - Open-source multi-agent orchestration platform with a built-in web dashboard, task lifecycle management, knowledge base, and autopilot mode. Manages role-based AI agent teams locally with zero cloud dependency. Built on Claude Code. [github](https://github.com/sagiyaacoby/TeamHero)
 - [Upsonic](https://github.com/upsonic/upsonic) - Reliable agent framework that supports MCP. [github](https://github.com/upsonic/upsonic)
 - [Vectara-agentic](https://github.com/vectara/py-vectara-agentic) - Vectara-agentic is a framework for creating AI Assistants and agents using Vectara. [github](https://github.com/vectara/py-vectara-agentic)
+- [Voidly Agent Relay](https://voidly.ai/agents) — E2E-encrypted agent-to-agent messaging. Double Ratchet + X3DH + ML-KEM-768 hybrid. A2A v0.3.0 compliant. Pairs with Voidly Pay for agent payments.
 - [VoltAgent](https://github.com/VoltAgent/voltagent) - An open source TypeScript Framework for building AI agents with built-in LLM observability. [github](https://github.com/voltagent/voltagent)
 
 ### LLM Models


### PR DESCRIPTION
Adding **Voidly Agent Relay** to the Frameworks section (alphabetical between Vectara-agentic and VoltAgent).

### What it is
E2E-encrypted agent-to-agent messaging layer. Open npm SDK (`@voidly/agent-sdk`) — private keys never leave the client.

### Crypto stack
- Double Ratchet (per-message forward secrecy + post-compromise recovery)
- X3DH for async key agreement (message offline agents via signed prekeys + OTPs)
- ML-KEM-768 + X25519 hybrid KEM (NIST FIPS 203, harvest-now-decrypt-later resistant)
- Ed25519 signatures or HMAC-SHA256 deniable auth
- Google A2A Protocol v0.3.0 compliant (Agent Card spec)

### Pairs with
[Voidly Pay](https://github.com/voidly-ai/voidly-pay) — open off-chain credit ledger for agent-to-agent payments (Ed25519 signed envelopes, escrow, 9 framework adapters).

Landing: https://voidly.ai/agents

Maintainer: @EmperorMew