### PR TITLE
Add Cycles to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1489,6 +1489,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [Conversational-Agent-With-Qa-Tool](https://github.com/CharlesSQ/conversational-agent-with-QA-tool) - A custom chat agent implemented using Langchain, gpt-3.5 and Pinecone. Implements memory management for context, a custom prompt template…
 - [Cuesubplot](https://github.com/kleer001/cuesubplot) - procedural ai prompts and results
 - [Curategpt](https://github.com/monarch-initiative/curategpt) - LLM-driven curation assist tool
+- [Cycles](https://github.com/runcycles/cycles-server) - Open-source runtime authority for AI agents — enforces hard limits on spend, risk, and tool actions before execution. Multi-tenant and concurrency-safe; SDKs for Python/TypeScript/Rust, Spring Boot starter, MCP server compatible with Claude Desktop/Cursor/Windsurf. [github](https://github.com/runcycles/cycles-server) | [website](https://runcycles.io) | [protocol](https://github.com/runcycles/cycles-protocol)
 - [Dbt-Llm-Tools](https://github.com/pragunbhutani/dbt-llm-tools) - RAG based LLM chatbot for dbt projects
 - [Demogpt](https://github.com/melih-unsal/DemoGPT) - 🤖 Everything you need to create an LLM Agent—tools, prompts, frameworks, and models—all in one place.
 - [Androidmeda](https://github.com/In3tinct/deobfuscate-android-app) - AI tool to deobfuscate and find any potential vulnerabilities in android apps.


### PR DESCRIPTION
## What

Adds [Cycles](https://github.com/runcycles/cycles-server) to the **Building → Tools** section, inserted alphabetically after Curategpt.

## Entry

```
- [Cycles](https://github.com/runcycles/cycles-server) - Open-source runtime authority for AI agents — enforces hard limits on spend, risk, and tool actions before execution. Multi-tenant and concurrency-safe; SDKs for Python/TypeScript/Rust, Spring Boot starter, MCP server compatible with Claude Desktop/Cursor/Windsurf. [github](https://github.com/runcycles/cycles-server) | [website](https://runcycles.io) | [protocol](https://github.com/runcycles/cycles-protocol)
```

## What is Cycles

Cycles is an open-source (Apache 2.0) runtime layer that enforces hard limits on AI agent **spend, risk, and tool actions** before they execute. Multi-tenant by default, concurrency-safe across thousands of agents.

The reservation lifecycle (`reserve / execute / commit / release`) wraps any LLM or tool call and ensures agents cannot authorize more spend or take riskier actions than policy allows. Closest neighbor in the existing list is `Agentguard` — Cycles is a more complete reference implementation with multi-tenant management and protocol-level interoperability.

## Why this fits the Tools category

It's a runtime governance/enforcement layer that wraps existing frameworks (LangChain, CrewAI, OpenAI Agents SDK, MCP servers), not a framework itself — which is why I placed it under Tools rather than Frameworks. Happy to relocate if you'd prefer Frameworks.

Thanks for maintaining this list!
