### PR TITLE
Add Nylas-Cli under Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1573,6 +1573,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [Nano-Bots](https://github.com/icebaker/nano-bots) - Repository for Nano Bots' Cartridges - small, AI-powered bots that can be easily shared as a single file, designed to support multiple pro…
 - [Nano-Bots-Api](https://github.com/icebaker/nano-bots-api) - HTTP API for Nano Bots - small, AI-powered bots that can be easily shared as a single file, designed to support multiple providers such as…
 - [Notiongpt](https://github.com/Suiwan/notionGPT) - NotionGPT, a practical tool built on top of ChatGPT large language model, make it your note-taking assistant!
+- [Nylas-Cli](https://github.com/nylas/cli) - Email, calendar, and contacts MCP server. 16 tools spanning Gmail, Outlook, Exchange, Yahoo, iCloud, and IMAP via a single auth flow. Gives AI agents a real email account and working calendar. [github](https://github.com/nylas/cli) | [docs](https://cli.nylas.com)
 - [Ollama-Mcp-Bridge](https://github.com/patruff/ollama-mcp-bridge) - Bridge between Ollama and MCP servers, enabling local LLMs to use Model Context Protocol tools
 - [Open-Webui-Tools](https://github.com/Haervwe/open-webui-tools) - a Repository of Open-WebUI tools to use with your favourite LLMs
 - [Openai-Tools](https://github.com/tipani86/OpenAI-Tools) - Toolkit to get the most out of your OpenAI Account


### PR DESCRIPTION
Adds Nylas-Cli to the Tools section, alphabetically between Notiongpt and Ollama-Mcp-Bridge.

**What it is:** Email, calendar, and contacts MCP server. 16 tools across Gmail, Outlook, Exchange, Yahoo, iCloud, and IMAP via one auth flow. Gives AI agents a real email account and working calendar.

**Source:** https://github.com/nylas/cli
**Docs:** https://cli.nylas.com