### PR TITLE
Add Sparkbtcbot-Skill — Bitcoin L2 wallet skill for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1597,6 +1597,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [Simple-Llm-Exporter](https://github.com/realityinspector/simple-llm-exporter) - a tool to export entire scripts to a text file with a file tree and description, for exporting to llm's
 - [SkillLite](https://github.com/EXboys/skilllite) - A lightweight, zero-dependency runtime for the agentsskills protocol that enables AI agents to securely execute portable skills locally. Written in Rust with native OS sandboxing, millisecond cold starts, single binary deployment [github](https://github.com/EXboys/skilllite)
 - [Smart_Fault_Injector_Llm](https://github.com/JiaHuann/Smart_Fault_Injector_LLM) - Intelligent kernel error injection/testing tool based on large model and eBPF.(基于大模型和eBPF的智能化kernel错误注入、测试工具)
+- [Sparkbtcbot-Skill](https://github.com/echennells/sparkbtcbot-skill) - Spark Bitcoin L2 wallet skill for AI agents — encrypted seed storage, instant zero-fee Spark transfers, Lightning Network interop (BOLT11), L402 paywall payment, BTKN/LRC20 tokens, L1 deposits and cooperative withdrawals.
 - [Speech-To-Code](https://github.com/dharllc/speech-to-code) - llm assisted development tools
 - [Speechless](https://github.com/uukuguy/speechless) - LLM based agents with proactive interactions, long-term memory, external tool integration, and local deployment capabilities.
 - [Splaa](https://github.com/cp3249/splaa) - SPLAA is an AI assistant framework that utilizes voice recognition, text-to-speech, and tool-calling capabilities to provide a conversati…


### PR DESCRIPTION
Adds [Sparkbtcbot-Skill](https://github.com/echennells/sparkbtcbot-skill) to **Building → Tools**.

**What it is:** A skill that gives an AI agent a non-custodial Bitcoin wallet on Spark (Bitcoin L2). Lets agents send/receive sats, pay/create Lightning invoices (BOLT11), pay L402-gated APIs, transfer BTKN/LRC20 tokens, deposit from L1, withdraw to L1, and sign messages. Seed encrypted at rest (scrypt + AES-256-GCM); decrypted at boot from `SPARK_PASSPHRASE`.

**Why this list:** Agents that earn or spend money need a wallet. The Tools section currently has finance-adjacent entries (Yahoo-Finance-Llm-Agent, Stock-Analysis-With-Llm) but no transactional wallet capability for autonomous agents.

**Compatibility:** Works with Claude Code via the plugin marketplace, and with any other LLM agent framework (Cursor, LangChain, OpenAI Agents SDK, Aider, etc.) via the `sparkbtcbot-skill` npm package.