### PR TITLE
Add Akephalos to tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1432,6 +1432,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [Cortex](https://github.com/SKULLFIRE07/cortex-memory) - Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context across sessions. VSCode extension + CLI + MCP server. Free.
 - [3Gpp-Requirements-Tools](https://github.com/Adrian2901/3gpp-requirements-tools) - Tools for retrieving 3GPP standards and LLM-powered requirement elicitiation.
 - [Acm](https://github.com/dnanhkhoa/acm) - A dead-simple AI-powered CLI tool for effortlessly crafting meaningful Git commit messages
+- [Akephalos](https://github.com/sunnja69/akephalos) - Local-first, markdown-first `.akephalos` passport for AI agents: portable preferences, tool notes, rules, project context, and durable memories across coding agents and MCP-compatible clients via plain files/Git.
 - [Agent-Manager-Skill](https://github.com/fractalmind-ai/agent-manager-skill) - tmux + Python agent lifecycle manager for running multiple CLI AI agents (start/stop/monitor/assign) with cron-friendly scheduling.
 - [Acte](https://github.com/j66n/acte) - A framework to build GUI-like Agent Tools, enhancement to Function Calling of LLM AI.
 - [Agentcloud](https://github.com/rnadigital/agentcloud) - Agent Cloud is like having your own GPT builder with a bunch extra goodies. The GUI features 1) RAG pipeline which can natively embed 260…


### PR DESCRIPTION
Adds Akephalos to the Tools section.

Akephalos is a local-first, markdown-first `.akephalos` passport for portable non-secret preferences, tool notes, rules, project context, and durable memories across AI/coding agents and MCP-compatible clients via plain files/Git.

Accuracy notes:
- current public repo/tag: sunnja69/akephalos v0.1.0
- early MVP-stage
- no hosted cloud sync, dashboard, OAuth, vector DB, or blockchain implied