### PR TITLE
Add EFC (Everything Fact-Checked) — fact-checking tool for AI research reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1501,6 +1501,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [Emergent](https://github.com/kyb3r/emergent) - An implementation of long term memory and external tools for LLMs
 - [Empower-Functions](https://github.com/empower-ai/empower-functions) - GPT-4 level function calling models for real-world tool using use cases
 - [Erag](https://github.com/EdwardDali/erag) - an AI interaction tool with RAG hybrid search, conversation context, web content processing and structured data analysis with LLM / GPT
+- [EFC (Everything Fact-Checked)](https://github.com/Nlai741533/EFC-Plugin) - Fact-checking tool for AI-generated research reports. Catches 5 systematic failure modes (unit errors, fabricated interpolation, source conflation, stale data, attribution laundering). Agent-agnostic SKILL.md + CLI (`efc`) + GitHub Action. [standalone skill](https://github.com/Nlai741533/EFC-standalone)
 - [Flotorch](https://github.com/FissionAI/FloTorch) - FloTorch is an open-source tool for optimizing Generative AI workloads on AWS. It automates RAG proof-of-concept development with feature…
 - [Flux](https://github.com/paradigmxyz/flux) - Graph-based LLM power tool for exploring many completions in parallel.
 - [Formfill](https://github.com/wdhorton/formfill) - FormFill is a CLI tool that uses LLMs to automatically fill out PDF forms.


### PR DESCRIPTION
## EFC (Everything Fact-Checked)

Fact-checking tool for AI-generated research reports.

**What it does:** Catches 5 systematic failure modes in AI agent research output:
1. Unit/scale errors (\.2B → \,200B)
2. Fabricated interpolation (invented data points in charts)
3. Source conflation (GMV vs revenue, etc.)
4. Stale data presented as current
5. Attribution laundering (weak sources cited as strong)

**Formats:** Agent-agnostic SKILL.md + CLI (`efc`) + GitHub Action

**Tech:** Stdlib Python, MIT license, 72 tests, zero dependencies

- Repo: https://github.com/Nlai741533/EFC-Plugin
- Standalone skill: https://github.com/Nlai741533/EFC-standalone