### PR TITLE
feat: add The Stall — x402 pay-per-call MCP server (210 capabilities, v4.64.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1429,6 +1429,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 
 
 ### Tools
+- [The Stall](https://github.com/thebrierfox/the-stall) - x402 pay-per-call MCP server with 173 data capabilities for AI agents. Covers financial markets, DeFi analytics, macro intelligence, crypto, weather, government data, and more — no API keys or subscriptions needed, pay per call in USDC on Base.
 - [Cortex](https://github.com/SKULLFIRE07/cortex-memory) - Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context across sessions. VSCode extension + CLI + MCP server. Free.
 - [3Gpp-Requirements-Tools](https://github.com/Adrian2901/3gpp-requirements-tools) - Tools for retrieving 3GPP standards and LLM-powered requirement elicitiation.
 - [Acm](https://github.com/dnanhkhoa/acm) - A dead-simple AI-powered CLI tool for effortlessly crafting meaningful Git commit messages


### PR DESCRIPTION
## Add The Stall to Tools section

[The Stall](https://github.com/thebrierfox/the-stall) is an x402 pay-per-call MCP server that gives AI agents access to 173 data capabilities with no API key provisioning or subscription management.

### Capabilities
- 📈 Financial markets: real-time stock prices, options chains, ETF holdings, earnings data, SEC filings, insider trades
- 🪙 DeFi & crypto: DEX liquidity, funding rates, wallet screening, EVM transaction analysis, yield protocols
- 🌍 Macro & policy: FOMC tracker, government votes, federal contracts, sanctions screening, IMF country data
- 🔍 General: news sentiment, weather alerts, clinical trials, flight tracking, NPI lookup, and more

### Why it belongs here
Most agent tools require per-service API key setup. The Stall solves this with x402 protocol — agents pay per call in USDC on Base. No credentials to manage, no rate limit handling, natural per-call cost tracking. Makes data access a plug-and-play primitive for any MCP-compatible agent.

**Note:** Open-source, MCP-conformant (Streamable HTTP transport), live on Base mainnet.
