### PR TITLE
Add AccInt to AI agent tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1431,6 +1431,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 ### Tools
 - [Cortex](https://github.com/SKULLFIRE07/cortex-memory) - Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context across sessions. VSCode extension + CLI + MCP server. Free.
 - [3Gpp-Requirements-Tools](https://github.com/Adrian2901/3gpp-requirements-tools) - Tools for retrieving 3GPP standards and LLM-powered requirement elicitiation.
+- [AccInt](https://accint.xyz) - MCP-native agent memory substrate that retrieves scored project context before actions, records outcomes, and supports cross-session coordination for coding and research agents. [github](https://github.com/maxbaluev/accreted-intelligence)
 - [Acm](https://github.com/dnanhkhoa/acm) - A dead-simple AI-powered CLI tool for effortlessly crafting meaningful Git commit messages
 - [Agent-Manager-Skill](https://github.com/fractalmind-ai/agent-manager-skill) - tmux + Python agent lifecycle manager for running multiple CLI AI agents (start/stop/monitor/assign) with cron-friendly scheduling.
 - [Acte](https://github.com/j66n/acte) - A framework to build GUI-like Agent Tools, enhancement to Function Calling of LLM AI.


### PR DESCRIPTION
## Summary
- Add AccInt to the Tools section as an MCP-native agent memory substrate for coding and research agents.
- Link to the public product page plus the public GitHub docs/glue repository.

## Fit
AccInt is relevant to AI-agent builders because it provides scored project memory retrieval before actions, outcome recording, and cross-session coordination through MCP-style agent workflows.

## Validation
- `git diff --check`
- `curl -I -L https://accint.xyz`
- `curl -I -L https://github.com/maxbaluev/accreted-intelligence`
