### PR TITLE
Add cowork-to-code-bridge to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1429,6 +1429,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 
 
 ### Tools
+- [Cowork-To-Code-Bridge](https://github.com/abhinaykrupa/cowork-to-code-bridge) - MCP server for Claude Code subscription as local execution backend for agents. Zero network ports, token-authenticated, production-ready. Enables agents to escalate code tasks locally without API key management.
 - [Cortex](https://github.com/SKULLFIRE07/cortex-memory) - Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context across sessions. VSCode extension + CLI + MCP server. Free.
 - [3Gpp-Requirements-Tools](https://github.com/Adrian2901/3gpp-requirements-tools) - Tools for retrieving 3GPP standards and LLM-powered requirement elicitiation.
 - [Acm](https://github.com/dnanhkhoa/acm) - A dead-simple AI-powered CLI tool for effortlessly crafting meaningful Git commit messages


### PR DESCRIPTION
## Summary

Adding cowork-to-code-bridge to the Tools section as an MCP-based execution backend for agents.

## Entry

**cowork-to-code-bridge** — MCP server for Claude Code subscription as local execution backend for agents. Zero network ports, token-authenticated, production-ready. Enables agents to escalate code tasks locally without API key management.

## Why this matters

Essential tool for agents needing local code execution without cloud dependencies or separate API billing. Complements agent frameworks by providing the execution layer.

Production-ready: 570 lines, 9 unit tests, live integrations with agent frameworks.