### PR TITLE
Add Novu Connect to Building > Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1573,6 +1573,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [Nano-Bots](https://github.com/icebaker/nano-bots) - Repository for Nano Bots' Cartridges - small, AI-powered bots that can be easily shared as a single file, designed to support multiple pro…
 - [Nano-Bots-Api](https://github.com/icebaker/nano-bots-api) - HTTP API for Nano Bots - small, AI-powered bots that can be easily shared as a single file, designed to support multiple providers such as…
 - [Notiongpt](https://github.com/Suiwan/notionGPT) - NotionGPT, a practical tool built on top of ChatGPT large language model, make it your note-taking assistant!
+- [Novu Connect](https://novu.co/connect) - Give your AI agent a presence across every messaging channel (Slack, Teams, WhatsApp) with synced conversation threading, and let it connect external MCP tools mid-conversation. [github](https://github.com/novuhq/novu)
 - [Ollama-Mcp-Bridge](https://github.com/patruff/ollama-mcp-bridge) - Bridge between Ollama and MCP servers, enabling local LLMs to use Model Context Protocol tools
 - [Open-Webui-Tools](https://github.com/Haervwe/open-webui-tools) - a Repository of Open-WebUI tools to use with your favourite LLMs
 - [Openai-Tools](https://github.com/tipani86/OpenAI-Tools) - Toolkit to get the most out of your OpenAI Account


### PR DESCRIPTION
Adding **Novu Connect** to the Building > Tools section, placed alphabetically.

Novu Connect gives an AI agent a presence across every messaging channel (Slack, Teams, WhatsApp) with synced conversation threading, and lets the agent connect external MCP tools mid-conversation. Open source, try with `npx novu connect`.

- Website: https://novu.co/connect
- Source: https://github.com/novuhq/novu