### PR TITLE
Add Xquik to AI agent tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1622,6 +1622,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [Widemem-Ai](https://github.com/remete618/widemem-ai) - Lightweight Python memory layer for LLM agents with importance scoring, temporal decay, 3-tier hierarchical memory, YMYL prioritization, and batch conflict resolution. Local-first with SQLite + FAISS. [github](https://github.com/remete618/widemem-ai) | [website](https://widemem.ai) | [pypi](https://pypi.org/project/widemem-ai/)
 - [Wildguard](https://github.com/allenai/wildguard) - Open One-Stop Moderation Tools for Safety Risks, Jailbreaks, and Refusals of LLMs
 - [Wxflows](https://github.com/IBM/wxflows) - Examples and tutorials for building AI applications with watsonx.ai Flows Engine
+- [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) - X automation API and MCP server for agent workflows: search tweets, look up users, export followers, fetch media, monitor events, and trigger confirmation-gated X actions. [website](https://xquik.com) | [docs](https://docs.xquik.com/mcp/overview) | [npm](https://www.npmjs.com/package/x-twitter-scraper)
 - [Xemantic-Ai-Tool-Schema](https://github.com/xemantic/xemantic-ai-tool-schema) - Kotlin multiplatform AI/LLM tool use (function calling) JSON Schema generator
 - [Yahoo-Finance-Llm-Agent](https://github.com/ojasskapre/yahoo-finance-llm-agent) - The Yahoo Finance Agent is an application that combines OpenAI's LLMs, the Yahoo Finance Python library, and LangChain's tools to provide…
 - [Zahara-Litellm](https://github.com/LiquidAdTech/Zahara-LiteLLM) - Gen AI tools


### PR DESCRIPTION
## Summary
- Add Xquik to the AI agent tools list.
- Link the public repo, docs, website, and npm package.

## Validation
- Confirmed no existing Xquik entry in the repository, recent PRs, or recent issues.
- Confirmed root Apache-2.0 license.
- Checked public Xquik docs, website, GitHub repo, and npm package metadata.
- Ran diff whitespace validation.
