### PR TITLE
Add Publora to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1429,6 +1429,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 
 
 ### Tools
+- [Publora](https://github.com/publora/mcp-server) - Official MCP server to schedule and publish social media posts across 10 platforms (X, LinkedIn, Instagram, Threads, TikTok, YouTube, Facebook, Bluesky, Mastodon, Telegram) from Claude, Cursor, or any MCP client. 18 tools including LinkedIn analytics.
 - [Cortex](https://github.com/SKULLFIRE07/cortex-memory) - Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context across sessions. VSCode extension + CLI + MCP server. Free.
 - [3Gpp-Requirements-Tools](https://github.com/Adrian2901/3gpp-requirements-tools) - Tools for retrieving 3GPP standards and LLM-powered requirement elicitiation.
 - [Acm](https://github.com/dnanhkhoa/acm) - A dead-simple AI-powered CLI tool for effortlessly crafting meaningful Git commit messages


### PR DESCRIPTION
Adds Publora to the Tools section — the official MCP server for scheduling and publishing social media posts across 10 platforms from Claude, Cursor, or any MCP client. Open-source (MIT), listed on Glama. Thanks for the great list!