### PR TITLE
Add Tree Ring Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1605,6 +1605,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [Structgenius](https://github.com/jaadbarg/StructGenius) - Download boilerplate file structure of any tree diagram you give
 - [Tapir](https://github.com/ephes/tapir) - Some llm tools
 - [Textcloak](https://github.com/umutcamliyurt/TextCloak) - A tool for concealing writing style using LLM
+- [Tree Ring Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory) - Framework-agnostic, local-first memory lifecycle for AI agents: Rust CLI, SQLite/FTS recall, forgetting, audit, consolidation, DOX/Revolve adapters, and TUI.
 - [Thoughtloom](https://github.com/tbiehn/thoughtloom) - ThoughtLoom is a powerful tool designed to foster creativity and enhance productivity through the use of LLMs directly from the command l…
 - [Tiger](https://github.com/Upsonic/Tiger) - No Crypto - Scam alarm - This project is not releated with any crypto currencies. | Neuralink for your AI Agents - LangChain - Autogen - …
 - [Toolcommander](https://github.com/NicerWang/ToolCommander) - Official implementation of "From Allies to Adversaries - Manipulating LLM Tool Scheduling through Adversarial Injection".


### PR DESCRIPTION
## Summary
- Add Tree Ring Memory to the Tools section
- Link to the public GitHub repo with the local-first AI-agent memory description

## Checks
- git diff --check