### PR TITLE
Add CodeAlmanac

### DIFF
--- a/README.md
+++ b/README.md
@@ -1483,6 +1483,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [ChatSpatial](https://github.com/cafferychen777/ChatSpatial) - MCP server enabling spatial transcriptomics analysis via natural language. Integrates 60+ methods for spatial domains, deconvolution, cell communication, and trajectory analysis.
 - [Claude-Powered-Study-Assistant](https://github.com/g-hano/Claude-Powered-Study-Assistant) - A study assistant powered by Claude Opus. It provides various tools to assist with different tasks, such as researching,coding,note-takin…
 - [Claudesync](https://github.com/jahwag/ClaudeSync) - ClaudeSync is a Python tool that automates the synchronization of local files with Claude.ai Projects
+- [CodeAlmanac](https://github.com/AlmanacCode/codealmanac) - Self-updating repo wiki for AI coding agents that tracks project conversations, decisions, and context locally.
 - [Code-Interpreter-Api](https://github.com/leezhuuuuu/Code-Interpreter-Api) - Committed to being the best code interpreter in the world.
 - [Comfyui-Llm-Tools](https://github.com/pridkett/ComfyUI-llm-tools) - Helpful nodes for working with LLMs inside of ComfyUI
 - [Companion](https://github.com/rapmd73/Companion) - An AI-powered Discord bot blending playful conversation with smart moderation tools, adding charm and order to your server.


### PR DESCRIPTION
Adds CodeAlmanac to the Tools section.

Why it fits:
- tool for AI coding agents
- keeps project conversations, decisions, and context locally in the repo
- helps agents reuse prior project context across sessions

Validation:
- read README contribution guidelines
- checked for duplicate CodeAlmanac entry
- ran `git diff --check`
