### PR TITLE
Add OpenAgentRelay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1573,7 +1573,8 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [Nano-Bots](https://github.com/icebaker/nano-bots) - Repository for Nano Bots' Cartridges - small, AI-powered bots that can be easily shared as a single file, designed to support multiple pro…
 - [Nano-Bots-Api](https://github.com/icebaker/nano-bots-api) - HTTP API for Nano Bots - small, AI-powered bots that can be easily shared as a single file, designed to support multiple providers such as…
 - [Notiongpt](https://github.com/Suiwan/notionGPT) - NotionGPT, a practical tool built on top of ChatGPT large language model, make it your note-taking assistant!
-- [Ollama-Mcp-Bridge](https://github.com/patruff/ollama-mcp-bridge) - Bridge between Ollama and MCP servers, enabling local LLMs to use Model Context Protocol tools
+- [Ollama-Mcp-Bridge](https://github.com/patruff/ollama-mcp-bridge)
+- [OpenAgentRelay](https://github.com/ShakespeareLabs/open-agent-relay) - Apache-2.0 CLI that exposes an existing local agent or automation as a capability callable by teammates or other agents over a trusted LAN. Current Alpha uses plain HTTP and a shared key. - Bridge between Ollama and MCP servers, enabling local LLMs to use Model Context Protocol tools
 - [Open-Webui-Tools](https://github.com/Haervwe/open-webui-tools) - a Repository of Open-WebUI tools to use with your favourite LLMs
 - [Openai-Tools](https://github.com/tipani86/OpenAI-Tools) - Toolkit to get the most out of your OpenAI Account
 - [Pathology_Llm](https://github.com/JaesikKim/pathology_llm) - GPT-4 as decision support tool in oncology


### PR DESCRIPTION
Adds OpenAgentRelay to **Tools**. The project is an Apache-2.0 Python CLI for making an existing local agent or automation callable by teammates or other agents over a trusted LAN while the publisher keeps the implementation and credentials on their own machine.

The description states the current Alpha boundary explicitly and links to the canonical public repository.