### PR TITLE
Add Writing-Driven Autoresearch to Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1027,6 +1027,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [Upsonic](https://github.com/upsonic/upsonic) - Reliable agent framework that supports MCP. [github](https://github.com/upsonic/upsonic)
 - [Vectara-agentic](https://github.com/vectara/py-vectara-agentic) - Vectara-agentic is a framework for creating AI Assistants and agents using Vectara. [github](https://github.com/vectara/py-vectara-agentic)
 - [VoltAgent](https://github.com/VoltAgent/voltagent) - An open source TypeScript Framework for building AI agents with built-in LLM observability. [github](https://github.com/voltagent/voltagent)
+- [Writing-Driven Autoresearch](https://github.com/happyhappy-jun/writing-driven-autoresearch) - A multi-agent harness in which autonomous LLM agents maintain a submittable paper from minute zero and drive experiments from it [github](https://github.com/happyhappy-jun/writing-driven-autoresearch) | [blog](https://byungjunyoon.ai/writing-driven-autoresearch/)
 
 ### LLM Models
 - [42Dot_Llm](https://github.com/42dot/42dot_LLM) - 42dot LLM consists of a pre-trained language model, 42dot LLM-PLM, and a fine-tuned model, 42dot LLM-SFT, which is trained to respond to …


### PR DESCRIPTION
Writing-Driven Autoresearch (https://github.com/happyhappy-jun/writing-driven-autoresearch) is a multi-agent harness in which autonomous LLM agents keep a submittable paper from minute zero and drive every experiment from the claims in that draft. Separate master, experiment, and writing agents coordinate only through files on disk, and build-time checks separate measured values from unverified placeholders.

Added to the Frameworks section in alphabetical order.

- Repo: https://github.com/happyhappy-jun/writing-driven-autoresearch
- Writeup: https://byungjunyoon.ai/writing-driven-autoresearch/

Thanks for maintaining awesome_ai_agents!