### PR TITLE
Add Zooid (self-hostable surface for running/supervising AI agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1027,6 +1027,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [Upsonic](https://github.com/upsonic/upsonic) - Reliable agent framework that supports MCP. [github](https://github.com/upsonic/upsonic)
 - [Vectara-agentic](https://github.com/vectara/py-vectara-agentic) - Vectara-agentic is a framework for creating AI Assistants and agents using Vectara. [github](https://github.com/vectara/py-vectara-agentic)
 - [VoltAgent](https://github.com/VoltAgent/voltagent) - An open source TypeScript Framework for building AI agents with built-in LLM observability. [github](https://github.com/voltagent/voltagent)
+- [Zooid](https://github.com/zooid-ai/zooid) - Self-hostable team-chat surface (Slack alternative on Matrix) and orchestrator where you run and supervise AI agents as first-class teammates. Any ACP agent (Claude Code, Codex, opencode, goose) runs sandboxed with approval cards, tool calls, and live plans. MIT. [github](https://github.com/zooid-ai/zooid) | [website](https://zooid.dev)
 
 ### LLM Models
 - [42Dot_Llm](https://github.com/42dot/42dot_LLM) - 42dot LLM consists of a pre-trained language model, 42dot LLM-PLM, and a fine-tuned model, 42dot LLM-SFT, which is trained to respond to …


### PR DESCRIPTION
Adds **Zooid** to the **Building → Frameworks** section, alongside the other orchestration/self-hostable platforms already listed there (TeamHero, Dust, Botpress, Khoj).

Zooid is not an AI agent itself — it is the **surface / orchestrator you run agents in**: an open-source, self-hostable **Slack alternative built on Matrix** where any ACP agent (Claude Code, Codex, opencode, goose) runs as a supervised, first-class teammate (approval cards, tool calls, live plans, sandboxed).

- Repo: https://github.com/zooid-ai/zooid · Site: https://zooid.dev · License: MIT

Placed at the end of the section (alphabetical). I am the maker — happy to move it to a different section or reword if you prefer.
