### PR TITLE
Add Redcells to AI agent security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1244,6 +1244,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 ### Security
 - [Aip-Identity](https://github.com/the-nexus-guard/aip) - Agent Identity Protocol (AIP) provides cryptographic identity (Ed25519/DID), vouch-based trust graphs, and end-to-end encrypted messaging for AI agents. CLI and Python SDK available on PyPI (`pip install aip-identity`) [github](https://github.com/the-nexus-guard/aip) | [website](https://the-nexus-guard.github.io/aip/) | [docs](https://aip-service.fly.dev/docs)
 - [Agent-Repoguardian](https://github.com/flexigpt/agent-repoguardian) - An AI agent that does security scans and vulnerability analysis of code
+- [Redcells](https://redcells.net) - Automated adversarial testing platform for LLMs you own or control. Runs structured red-team jobs (prompt injection, jailbreak, data leakage, etc.) with iterative attack→refine layers and per-layer judge scoring via web dashboard or API. [repo](https://github.com/awdemos/redcell)
 - [Agentic_Security](https://github.com/msoedov/agentic_security) - Agentic LLM Vulnerability Scanner / AI red teaming kit
 - [Agentictrust](https://github.com/lab101-ai/agentictrust) - Observability, DevTool and Security Platfrom for AI Agents
 - [Agentos](https://github.com/The-Swarm-Corporation/AgentOS) - AgentOS implements a comprehensive security architecture leveraging containerization, orchestration, and multi-layer isolation to ensure …


### PR DESCRIPTION
Adds Redcells to the Security section.\n\nRedcells is a public-beta platform for automated adversarial testing of LLMs you own or control, useful for securing AI-agent pipelines that rely on target LLMs.\n\n- OpenAI-compatible target models\n- Structured red-team jobs (prompt injection, jailbreak, data leakage, etc.)\n- Iterative attack→refine pipeline with per-layer prompts, responses, and judge scores\n- Web dashboard + HTTP API for CI/CD integration\n\nWebsite: https://redcells.net | Repo: https://github.com/awdemos/redcell