### PR TITLE
Add BenchGen to Testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1289,6 +1289,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [Web_Scrape_Agent_Ai](https://github.com/rxslice/Web_Scrape_Agent_AI) - Enterprise-Quality Autonomous Agent complete with relevant tools, master prompt, additional optional AI services, API compatible, basic s…
 
 ### Testing
+- [BenchGen](https://benchgen.com) - AI agent benchmarking and evaluation platform. Runs structured benchmark suites, scores agents across tool-call accuracy, goal completion, and skill coverage, then exports filtered trajectories for fine-tuning. [website](https://benchgen.com)
 - [EvoAgentX](https://github.com/EvoAgentX/EvoAgentX) - EvoAgentX is building a Self-Evolving Ecosystem of AI Agents, it will give you automated framework for evaluating and evolving agentic workflows. [github](https://github.com/EvoAgentX/EvoAgentX)
 - [Open-RAG-Eval](https://github.com/vectara/open-rag-eval) - an open source RAG evaluation framework that does not require golden answers, and can be used to evaluate performance of RAG tools connected to an AI Agent (Agentic RAG). [github](https://github.com/vectara/open-rag-eval)
 - [Voice Lab](https://github.com/saharmor/voice-lab) - A comprehensive testing and evaluation framework for voice agents across language models, prompts, and agent personas. [github](https://github.com/saharmor/voice-lab)


### PR DESCRIPTION
Hey! Suggesting to add BenchGen (https://benchgen.com) to the Testing section.

It's an AI agent benchmarking and evaluation platform — run structured benchmarks against your agent, score it across tool-call accuracy, goal completion, and skill coverage, and export filtered trajectories for fine-tuning. Seems like a solid fit alongside the other testing and evaluation tools in that section.

Let me know if you want any tweaks.