### PR TITLE
Add Compartment to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1061,6 +1061,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [Ella](https://github.com/TencentQQGYLab/ELLA) - ELLA - Equip Diffusion Models with LLM for Enhanced Semantic Alignment
 - [Elm](https://github.com/NREL/elm) - ELM is a collection of utilities to apply Large Language Models (LLMs) to energy research.
 - [Empower-Functions](https://github.com/empower-ai/empower-functions) - GPT-4 level function calling models for real-world tool using use cases
+- [engRAM](https://github.com/MaxFreedomPollard/engRAM) - Fully offline, encrypted-at-rest vector memory store for AI agents, usable as an MCP server or a CLI/Python library. AEAD-encrypts everything at rest including embedding vectors, with RAM-resident hybrid vector + keyword search, per-record crypto-shred deletion, a hash-chained audit log, and optional keyfile two-factor unlock.
 - [Exaone-3.0](https://github.com/LG-AI-EXAONE/EXAONE-3.0) - Official repository for EXAONE built by LG AI Research
 - [Fastmcp](https://github.com/jlowin/fastmcp) - The fast, Pythonic way to build Model Context Protocol servers 🚀
 - [Fauno-Italian-Llm](https://github.com/RSTLess-research/Fauno-Italian-LLM) - Get ready to meet Fauno - the Italian language model crafted by the RSTLess Research Group from the Sapienza University of Rome.

--- a/README.md
+++ b/README.md
@@ -1051,6 +1051,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [Code-Interpreter](https://github.com/haseeb-heaven/code-interpreter) - An innovative open-source Code Interpreter with (GPT,Gemini,Claude,LLaMa) models.
 - [Codebase-For-Incremental-Learning-With-Llm](https://github.com/zzz47zzz/codebase-for-incremental-learning-with-llm) - [ACL2024] A Codebase for Incremental Learning with Large Language Models; Official released code for "Learn or Recall? Revisiting Increme…
 - [Codegen](https://github.com/salesforce/CodeGen) - CodeGen is a family of open-source model for program synthesis. Trained on TPU-v4. Competitive with OpenAI Codex.
+- [Compartment](https://github.com/MaxFreedomPollard/Compartment) - Fully offline, encrypted-at-rest vector memory store for AI agents, usable as an MCP server or a CLI/Python library. AEAD-encrypts everything at rest including embedding vectors, with RAM-resident hybrid vector + keyword search, per-record crypto-shred deletion, a hash-chained audit log, and optional keyfile two-factor unlock.
 - [Damo-Seallms](https://github.com/DAMO-NLP-SG/DAMO-SeaLLMs) - [ACL 2024 Demo] SeaLLMs - Large Language Models for Southeast Asia
 - [Datainf](https://github.com/ykwon0407/DataInf) - DataInf - Efficiently Estimating Data Influence in LoRA-tuned LLMs and Diffusion Models (ICLR 2024)
 - [Dellma](https://github.com/DeLLMa/DeLLMa) - Official Implementation of "DeLLMa - Decision Making Under Uncertainty with Large Language Models"
@@ -1061,7 +1062,6 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [Ella](https://github.com/TencentQQGYLab/ELLA) - ELLA - Equip Diffusion Models with LLM for Enhanced Semantic Alignment
 - [Elm](https://github.com/NREL/elm) - ELM is a collection of utilities to apply Large Language Models (LLMs) to energy research.
 - [Empower-Functions](https://github.com/empower-ai/empower-functions) - GPT-4 level function calling models for real-world tool using use cases
-- [engRAM](https://github.com/MaxFreedomPollard/engRAM) - Fully offline, encrypted-at-rest vector memory store for AI agents, usable as an MCP server or a CLI/Python library. AEAD-encrypts everything at rest including embedding vectors, with RAM-resident hybrid vector + keyword search, per-record crypto-shred deletion, a hash-chained audit log, and optional keyfile two-factor unlock.
 - [Exaone-3.0](https://github.com/LG-AI-EXAONE/EXAONE-3.0) - Official repository for EXAONE built by LG AI Research
 - [Fastmcp](https://github.com/jlowin/fastmcp) - The fast, Pythonic way to build Model Context Protocol servers 🚀
 - [Fauno-Italian-Llm](https://github.com/RSTLess-research/Fauno-Italian-LLM) - Get ready to meet Fauno - the Italian language model crafted by the RSTLess Research Group from the Sapienza University of Rome.


### PR DESCRIPTION
Adds **Compartment** to the Tools section (placed alphabetically, between Codegen and Damo-Seallms).

Compartment is a fully offline, encrypted-at-rest vector memory store for AI agents, usable as an MCP server or a CLI/Python library: AEAD-encrypts everything at rest including embedding vectors, RAM-resident hybrid vector + keyword search, per-record crypto-shred deletion, hash-chained audit log, optional keyfile two-factor unlock.

Repo: https://github.com/MaxFreedomPollard/Compartment

_Note: this project was previously submitted as **engRAM** and has since been renamed to **Compartment**. This PR has been updated in place — the entry now uses the new name, repo URL, and alphabetical position._
