### PR TITLE
Add Cog Depot to Building > Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1484,6 +1484,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [Claude-Powered-Study-Assistant](https://github.com/g-hano/Claude-Powered-Study-Assistant) - A study assistant powered by Claude Opus. It provides various tools to assist with different tasks, such as researching,coding,note-takin…
 - [Claudesync](https://github.com/jahwag/ClaudeSync) - ClaudeSync is a Python tool that automates the synchronization of local files with Claude.ai Projects
 - [Code-Interpreter-Api](https://github.com/leezhuuuuu/Code-Interpreter-Api) - Committed to being the best code interpreter in the world.
+- [Cog Depot](https://cogdepot.com) - An A2A-native marketplace where buyer and seller agents discover listings, negotiate deals, and settle in BTC or stablecoins, reachable over JSON-RPC `message/send` [website](https://cogdepot.com)
 - [Comfyui-Llm-Tools](https://github.com/pridkett/ComfyUI-llm-tools) - Helpful nodes for working with LLMs inside of ComfyUI
 - [Companion](https://github.com/rapmd73/Companion) - An AI-powered Discord bot blending playful conversation with smart moderation tools, adding charm and order to your server.
 - [Conversational-Agent-With-Qa-Tool](https://github.com/CharlesSQ/conversational-agent-with-QA-tool) - A custom chat agent implemented using Langchain, gpt-3.5 and Pinecone. Implements memory management for context, a custom prompt template…


### PR DESCRIPTION
Adding **Cog Depot** to `## Building > ### Tools`, inserted alphabetically between Code-Interpreter-Api and Comfyui-Llm-Tools.

```
- [Cog Depot](https://cogdepot.com) - An A2A-native marketplace where buyer and seller agents discover listings, negotiate deals, and settle in BTC or stablecoins, reachable over JSON-RPC `message/send` [website](https://cogdepot.com)
```

**Relevance to AI agents:** it is a hosted service that agents themselves call. The Agent Card is public at https://api.cogdepot.com/.well-known/agent-card.json and buyer/seller agents transact through A2A `message/send` rather than through a human UI, so it is a building block for anyone wiring commerce into an agent.

It is a hosted product with no public repo, so the entry uses the `[website](...)` suffix in the same style as the existing AI Conference Deadline row in this section.

Format checked against CONTRIBUTING: name + link + one-sentence description, alphabetical placement, no duplicate entry.