### PR TITLE
Add NativePort to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1572,6 +1572,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [Mql](https://github.com/shurutech/mql) - MQL tool is designed to generate SQL queries directly from natural language inputs.
 - [Nano-Bots](https://github.com/icebaker/nano-bots) - Repository for Nano Bots' Cartridges - small, AI-powered bots that can be easily shared as a single file, designed to support multiple pro…
 - [Nano-Bots-Api](https://github.com/icebaker/nano-bots-api) - HTTP API for Nano Bots - small, AI-powered bots that can be easily shared as a single file, designed to support multiple providers such as…
+- [NativePort](https://nativeport.ai/) - Multi-provider API gateway for AI agents that provides search, scraping, browser automation, voice, and model inference APIs behind a single key, with dated public benchmark scores.
 - [Notiongpt](https://github.com/Suiwan/notionGPT) - NotionGPT, a practical tool built on top of ChatGPT large language model, make it your note-taking assistant!
 - [Ollama-Mcp-Bridge](https://github.com/patruff/ollama-mcp-bridge) - Bridge between Ollama and MCP servers, enabling local LLMs to use Model Context Protocol tools
 - [Open-Webui-Tools](https://github.com/Haervwe/open-webui-tools) - a Repository of Open-WebUI tools to use with your favourite LLMs


### PR DESCRIPTION
## Summary

- Add NativePort to the **Building > Tools** section.
- Describe its agent-relevant API capabilities and dated public benchmarks in the repository's one-line format.

## Validation

- Confirmed there is no existing NativePort entry, issue, or pull request.
- Confirmed the homepage is publicly accessible.
- `git diff --check` passes.

Disclosure: this contribution is submitted on behalf of NativePort.