### PR TITLE
Add ChatBotKit to agent frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1001,6 +1001,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [Auto-GPT](https://github.com/Torantulino/Auto-GPT) - AutoGPT is the vision of accessible AI for everyone, to use and to build on. Our mission is to provide the tools, so that you can focus on what matters.
 - [Bernstein](https://github.com/chernistry/bernstein) - Deterministic multi-agent orchestrator that spawns parallel AI coding agents (Claude Code, Codex CLI, Gemini CLI) from a single goal, verifies with tests, and auto-commits. Zero LLM tokens on coordination. [github](https://github.com/chernistry/bernstein)
 - [Botpress](https://github.com/botpress/botpress) - The building blocks for building chatbots. [github](https://github.com/botpress/botpress)
+- [ChatBotKit](https://chatbotkit.com) - Build and deploy AI agents for support, sales, and operations across websites and messaging channels.
 - [Crew.AI](https://github.com/crewAIInc/crewAI) - Framework for orchestrating role-playing, autonomous AI agents. By fostering collaborative intelligence, CrewAI empowers agents to work together seamlessly, tackling complex tasks.
 - [Dust](https://github.com/dust-tt/dust) - Design and Deploy Large Language Model Apps. [github](https://github.com/dust-tt/dust)
 - [Giselle](https://giselles.ai/) - Giselle is an open source AI App Builder for agentic workflows. Giselle enables seamless human-AI collaboration, helping to automate complex tasks and streamline workflows efficiently [website](https://giselles.ai/)


### PR DESCRIPTION
Added `ChatBotKit` as a resource for building and deploying AI agents for support, sales, and operations across websites and messaging channels.