### PR TITLE
Add Lians agent memory tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1429,6 +1429,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 
 
 ### Tools
+- [Lians](https://github.com/Lians-ai/Lians) - Open-source, local-first memory for any AI agent, available through MCP and Python/TypeScript SDKs with inspectable, correctable, and deletable memory.
 - [Cortex](https://github.com/SKULLFIRE07/cortex-memory) - Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context across sessions. VSCode extension + CLI + MCP server. Free.
 - [3Gpp-Requirements-Tools](https://github.com/Adrian2901/3gpp-requirements-tools) - Tools for retrieving 3GPP standards and LLM-powered requirement elicitiation.
 - [Acm](https://github.com/dnanhkhoa/acm) - A dead-simple AI-powered CLI tool for effortlessly crafting meaningful Git commit messages


### PR DESCRIPTION
## What changed

Adds Lians to the Tools section with one concise, factual entry linking to its public repository.

## Why it belongs

Lians is an Apache-2.0, local-first memory layer for AI agents. It supports MCP plus Python and TypeScript SDKs, and users can inspect, correct, and delete stored memory.

## Validation

- Confirmed no existing Lians entry or open/closed Lians submission
- Kept the change to one README line
- Ran `git diff --check`

## Disclosure

I am affiliated with Lians. This contribution was drafted with AI assistance and reviewed against the repository's published contribution guidelines and the linked public repository.