### PR TITLE
Add LWC agent memory tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1430,6 +1430,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 
 ### Tools
 - [Cortex](https://github.com/SKULLFIRE07/cortex-memory) - Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context across sessions. VSCode extension + CLI + MCP server. Free.
+- [LWC (Local Wiki CLI)](https://github.com/JanYork/llm-wiki-cli) - Local-first, source-grounded project memory for coding agents with durable Markdown/SQLite storage, citations and provenance, bounded read-only MCP retrieval, atomic changesets, and optional document and code knowledge graphs.
 - [3Gpp-Requirements-Tools](https://github.com/Adrian2901/3gpp-requirements-tools) - Tools for retrieving 3GPP standards and LLM-powered requirement elicitiation.
 - [Acm](https://github.com/dnanhkhoa/acm) - A dead-simple AI-powered CLI tool for effortlessly crafting meaningful Git commit messages
 - [Agent-Manager-Skill](https://github.com/fractalmind-ai/agent-manager-skill) - tmux + Python agent lifecycle manager for running multiple CLI AI agents (start/stop/monitor/assign) with cron-friendly scheduling.


### PR DESCRIPTION
Adds [LWC (Local Wiki CLI)](https://github.com/JanYork/llm-wiki-cli) to the **Building Agents → Tools** section.

LWC is an Apache-2.0, local-first project-memory tool for coding agents. Its distinguishing capabilities are source-grounded durable memory, citations and provenance, atomic changesets, bounded read-only retrieval over MCP, and optional document/code knowledge graphs. The repository includes installation instructions and integrations for multiple coding agents.

Validation: canonical repository link checked and `git diff --check` passes.