### PR TITLE
Add DSH Studio to agent tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1430,6 +1430,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 
 ### Tools
 - [Cortex](https://github.com/SKULLFIRE07/cortex-memory) - Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context across sessions. VSCode extension + CLI + MCP server. Free.
+- [DSH Studio](https://github.com/Moresyl/dsh-studio) - Open-source cross-platform desktop host for installing, running, and managing DeepSeek Harness with an embedded web UI.
 - [3Gpp-Requirements-Tools](https://github.com/Adrian2901/3gpp-requirements-tools) - Tools for retrieving 3GPP standards and LLM-powered requirement elicitiation.
 - [Acm](https://github.com/dnanhkhoa/acm) - A dead-simple AI-powered CLI tool for effortlessly crafting meaningful Git commit messages
 - [Agent-Manager-Skill](https://github.com/fractalmind-ai/agent-manager-skill) - tmux + Python agent lifecycle manager for running multiple CLI AI agents (start/stop/monitor/assign) with cron-friendly scheduling.


### PR DESCRIPTION
Add [DSH Studio](https://github.com/Moresyl/dsh-studio) to the **Building → Tools** section. The entry follows the repository requirement of a relevant name, link, and one-sentence description.