### PR TITLE
Add ClawMetry to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1483,6 +1483,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [ChatSpatial](https://github.com/cafferychen777/ChatSpatial) - MCP server enabling spatial transcriptomics analysis via natural language. Integrates 60+ methods for spatial domains, deconvolution, cell communication, and trajectory analysis.
 - [Claude-Powered-Study-Assistant](https://github.com/g-hano/Claude-Powered-Study-Assistant) - A study assistant powered by Claude Opus. It provides various tools to assist with different tasks, such as researching,coding,note-takin…
 - [Claudesync](https://github.com/jahwag/ClaudeSync) - ClaudeSync is a Python tool that automates the synchronization of local files with Claude.ai Projects
+- [ClawMetry](https://github.com/vivekchand/clawmetry) - Zero-config observability dashboard for AI agent runtimes with session transcripts, token and cost analytics, and live traces.
 - [Code-Interpreter-Api](https://github.com/leezhuuuuu/Code-Interpreter-Api) - Committed to being the best code interpreter in the world.
 - [Comfyui-Llm-Tools](https://github.com/pridkett/ComfyUI-llm-tools) - Helpful nodes for working with LLMs inside of ComfyUI
 - [Companion](https://github.com/rapmd73/Companion) - An AI-powered Discord bot blending playful conversation with smart moderation tools, adding charm and order to your server.

--- a/README.md
+++ b/README.md
@@ -1483,7 +1483,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [ChatSpatial](https://github.com/cafferychen777/ChatSpatial) - MCP server enabling spatial transcriptomics analysis via natural language. Integrates 60+ methods for spatial domains, deconvolution, cell communication, and trajectory analysis.
 - [Claude-Powered-Study-Assistant](https://github.com/g-hano/Claude-Powered-Study-Assistant) - A study assistant powered by Claude Opus. It provides various tools to assist with different tasks, such as researching,coding,note-takin…
 - [Claudesync](https://github.com/jahwag/ClaudeSync) - ClaudeSync is a Python tool that automates the synchronization of local files with Claude.ai Projects
-- [ClawMetry](https://github.com/vivekchand/clawmetry) - Zero-config observability dashboard for AI agent runtimes with session transcripts, token and cost analytics, and live traces.
+- [ClawMetry](https://github.com/vivekchand/clawmetry) - Zero-config observability dashboard for AI agent runtimes with session transcripts, token and cost analytics, and live traces. [website](https://clawmetry.com)
 - [Code-Interpreter-Api](https://github.com/leezhuuuuu/Code-Interpreter-Api) - Committed to being the best code interpreter in the world.
 - [Comfyui-Llm-Tools](https://github.com/pridkett/ComfyUI-llm-tools) - Helpful nodes for working with LLMs inside of ComfyUI
 - [Companion](https://github.com/rapmd73/Companion) - An AI-powered Discord bot blending playful conversation with smart moderation tools, adding charm and order to your server.


### PR DESCRIPTION
Adds [ClawMetry](https://github.com/vivekchand/clawmetry) to the Tools section, inserted alphabetically between Claudesync and Code-Interpreter-Api.

ClawMetry is an open-source, zero-config observability dashboard for AI agent runtimes. It shows session transcripts, token and cost analytics, and live traces from a local pip install.

Website: https://clawmetry.com
