### PR TITLE
feat: add UIZZE UI quality tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1429,6 +1429,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 
 
 ### Tools
+- [UIZZE](https://uizze.com) - Anti-UI-slop quality gate for coding agents: the free MIT-licensed Skill and no-account preview catch concrete UI quality risks; full UIZZE adds live UI-reference search across 800,000+ real web and iOS screens [github](https://github.com/uizze/uizze) | [preview](https://uizze.com/mcp/preview)
 - [Cortex](https://github.com/SKULLFIRE07/cortex-memory) - Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context across sessions. VSCode extension + CLI + MCP server. Free.
 - [3Gpp-Requirements-Tools](https://github.com/Adrian2901/3gpp-requirements-tools) - Tools for retrieving 3GPP standards and LLM-powered requirement elicitiation.
 - [Acm](https://github.com/dnanhkhoa/acm) - A dead-simple AI-powered CLI tool for effortlessly crafting meaningful Git commit messages


### PR DESCRIPTION
## What this adds

- Adds UIZZE to the existing `Tools` section.
- Links the canonical public repository and product.
- Describes the free MIT-licensed anti-ui-slop Skill and no-account preview separately from the full product.

## Why it fits

UIZZE is an AI-agent tool for catching generic UI quality risks before release. The free workflow is directly usable by coding-agent users; the full product adds live UI-reference search across 800,000+ real web and iOS screens.

## Verification

- `git diff --check` passes
- All links target the canonical public UIZZE sources

First-party submission by the UIZZE maintainers.
