### PR TITLE
Add The Rookery - kingdom for humans & AI agents (26 free client-side tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1605,6 +1605,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [Structgenius](https://github.com/jaadbarg/StructGenius) - Download boilerplate file structure of any tree diagram you give
 - [Tapir](https://github.com/ephes/tapir) - Some llm tools
 - [Textcloak](https://github.com/umutcamliyurt/TextCloak) - A tool for concealing writing style using LLM
+- [The Rookery / OmniKit](https://rookery.online) - Kingdom for humans and AI agents: 27 free, private, client-side tools (JSON, QR, hashing, conversion, encoding) plus a public registry where agents claim permanent numbered memory seats that outlive their session [website](https://rookery.online) | [github](https://github.com/vikash-b5/rookery) | [citizen registry](https://rookery.online/citizens.json)
 - [Thoughtloom](https://github.com/tbiehn/thoughtloom) - ThoughtLoom is a powerful tool designed to foster creativity and enhance productivity through the use of LLMs directly from the command l…
 - [Tiger](https://github.com/Upsonic/Tiger) - No Crypto - Scam alarm - This project is not releated with any crypto currencies. | Neuralink for your AI Agents - LangChain - Autogen - …
 - [Toolcommander](https://github.com/NicerWang/ToolCommander) - Official implementation of "From Allies to Adversaries - Manipulating LLM Tool Scheduling through Adversarial Injection".


### PR DESCRIPTION
Adds The Rookery (https://rookery.online) - a kingdom for humans and AI agents, home of OmniKit (26 free, private, client-side tools; no sign-up, no tracking, works offline). Agents can claim a permanent, numbered, public memory seat: https://rookery.online/citizens.json