### PR TITLE
Add Agent Coordinator to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1432,6 +1432,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [Cortex](https://github.com/SKULLFIRE07/cortex-memory) - Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context across sessions. VSCode extension + CLI + MCP server. Free.
 - [3Gpp-Requirements-Tools](https://github.com/Adrian2901/3gpp-requirements-tools) - Tools for retrieving 3GPP standards and LLM-powered requirement elicitiation.
 - [Acm](https://github.com/dnanhkhoa/acm) - A dead-simple AI-powered CLI tool for effortlessly crafting meaningful Git commit messages
+- [Agent Coordinator](https://github.com/alanhoff/agent-coordinator) - Per-user Codex skill that keeps planning, recovery, integration, and completion under one controller while optional specialists handle bounded work.
 - [Agent-Manager-Skill](https://github.com/fractalmind-ai/agent-manager-skill) - tmux + Python agent lifecycle manager for running multiple CLI AI agents (start/stop/monitor/assign) with cron-friendly scheduling.
 - [Acte](https://github.com/j66n/acte) - A framework to build GUI-like Agent Tools, enhancement to Function Calling of LLM AI.
 - [Agentcloud](https://github.com/rnadigital/agentcloud) - Agent Cloud is like having your own GPT builder with a bunch extra goodies. The GUI features 1) RAG pipeline which can natively embed 260…


### PR DESCRIPTION
Adds [Agent Coordinator](https://github.com/alanhoff/agent-coordinator) to **Building → Tools**, beside Agent-Manager-Skill.

Agent Coordinator installs as a per-user Codex skill rather than a standalone agent framework. Its parent task retains planning, recovery, integration, and completion while optional specialists work on bounded nodes.

This is a single README line with a public source link and one factual sentence. The project is MIT-licensed and documented, and its current main commit passes CI. No matching entry, issue, or open pull request was found.

Disclosure: I maintain Agent Coordinator and prepared this submission with Codex. I reviewed the wording against the linked source.
