### PR TITLE
Add YYLO to Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1027,6 +1027,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 - [Upsonic](https://github.com/upsonic/upsonic) - Reliable agent framework that supports MCP. [github](https://github.com/upsonic/upsonic)
 - [Vectara-agentic](https://github.com/vectara/py-vectara-agentic) - Vectara-agentic is a framework for creating AI Assistants and agents using Vectara. [github](https://github.com/vectara/py-vectara-agentic)
 - [VoltAgent](https://github.com/VoltAgent/voltagent) - An open source TypeScript Framework for building AI agents with built-in LLM observability. [github](https://github.com/voltagent/voltagent)
+- [YYLO](https://github.com/yylo-dev/yylo) - Command-line orchestrator that runs AI coding agents (Claude Code, Codex, Gemini CLI) through Kanban-tracked tasks in isolated git worktrees, with typed validation, merge, and release-readiness boundaries. [github](https://github.com/yylo-dev/yylo) | [npm](https://www.npmjs.com/package/@yylo/cli)
 
 ### LLM Models
 - [42Dot_Llm](https://github.com/42dot/42dot_LLM) - 42dot LLM consists of a pre-trained language model, 42dot LLM-PLM, and a fine-tuned model, 42dot LLM-SFT, which is trained to respond to …


### PR DESCRIPTION
Adds [YYLO](https://github.com/yylo-dev/yylo) to the Frameworks section (alphabetically after VoltAgent, at the bottom of the section).

Command-line orchestrator that runs AI coding agents (Claude Code, Codex, Gemini CLI) through Kanban-tracked tasks in isolated git worktrees, with typed validation, merge, and release-readiness boundaries.

- Repo: https://github.com/yylo-dev/yylo (MIT, actively maintained, 56★)
- Install: `npm install --global '@yylo/cli'`
- Disclosure: I maintain YYLO.