### PR TITLE
Add ContextStream to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1429,6 +1429,7 @@ The key tools for building AI agents include benchmarks (to evaluate performance
 
 
 ### Tools
+- [ContextStream](https://contextstream.io) - Shared project context for Cursor, Claude Code, Codex, and Grok. Intelligence isn’t the bottleneck. Context is. Remote MCP: https://mcp.contextstream.io/mcp
 - [Cortex](https://github.com/SKULLFIRE07/cortex-memory) - Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context across sessions. VSCode extension + CLI + MCP server. Free.
 - [3Gpp-Requirements-Tools](https://github.com/Adrian2901/3gpp-requirements-tools) - Tools for retrieving 3GPP standards and LLM-powered requirement elicitiation.
 - [Acm](https://github.com/dnanhkhoa/acm) - A dead-simple AI-powered CLI tool for effortlessly crafting meaningful Git commit messages


### PR DESCRIPTION
## Summary
Add ContextStream, a shared project context MCP for Cursor, Claude Code, Codex, and Grok.

- Website: https://contextstream.io
- MCP: https://mcp.contextstream.io/mcp
- Benchmarks: https://contextstream.io/benchmarks
- Pitch: Intelligence isn’t the bottleneck. Context is.

I work on ContextStream. This is a free listing suggestion. $0.

## Test plan
- [ ] Confirm ContextStream was not already listed
- [ ] Confirm the row is in the intended section
- [ ] Confirm links resolve